### PR TITLE
Update: Link in setup.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 - fixed Broken "Permalink (to Clipboard)" functionality #4
   [enkidulan]
-
+- update url in setup.py, plone.org/products is gone
+  [svx]
 
 1.0.1 (2017-08-09)
 ------------------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@ Contributors
 
 - Red Turtle
 - Markus Hilbert, markus.hilbert@iham.at
+- Sven Strack, sven@so36.net

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     keywords='plone plonegov permalink',
     author='RedTurtle Technology',
     author_email='sviluppoplone@redturtle.it',
-    url='http://plone.org/products/collective.permalink',
+    url='https://github.com/collective/collective.permalink',
     license='GPL',
     packages=find_packages(exclude=['ez_setup']),
     namespace_packages=['collective'],


### PR DESCRIPTION
This Pull Request updates the link in setup.py to point to GitHub in place of the deprecated plone.org/products